### PR TITLE
Removed CAF from readable name

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "project_name": "Package Name",
     "caf": false,
-    "__readable_name": "{% if cookiecutter.caf %}CAF {% endif %}{{ cookiecutter.project_name }}",
+    "__readable_name": "{% if cookiecutter.caf %}CAF {% endif %}{{ cookiecutter.project_name|remove_prefix('caf.') }}",
     "package_name": "{% if cookiecutter.caf %}caf.{% endif %}{{ cookiecutter.project_name|pkg_name(True) }}",
     "project_slug": "{% if cookiecutter.caf %}caf.{% endif %}{{ cookiecutter.project_name|repo_name(True) }}",
     "author": "Transport for the North",
@@ -24,7 +24,8 @@
     },
     "_extensions": [
         "local_extensions.pkg_name",
-        "local_extensions.repo_name"
+        "local_extensions.repo_name",
+        "local_extensions.remove_prefix"
     ],
     "__prompts__": {
         "project_name": "Human-Readable Project Name",

--- a/local_extensions.py
+++ b/local_extensions.py
@@ -13,6 +13,11 @@ from cookiecutter.utils import simple_filter
 
 ##### CLASSES & FUNCTIONS #####
 
+@simple_filter
+def remove_prefix(name: str, prefix: str) -> str:
+    """Remove given prefix from name."""
+    prefix = re.escape(prefix)
+    return re.sub(rf"^{prefix}", "", name.strip(), flags=re.I)
 
 @simple_filter
 def pkg_name(name: str, remove_caf: bool = False) -> str:


### PR DESCRIPTION
Fixed issue with caf. being given in readable name, previous PR (#23) fixed the package and repo names but not the readable one.