### PR TITLE
Hiding README sections

### DIFF
--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -51,11 +51,7 @@ which is a collaboration between transport bodies in the UK to develop and maint
 transport analytics and appraisal tools.
 {% endif %}
 
-## Maintainers
-
-{% for maintainer in cookiecutter.project_maintainers.split(";") %}
-- {{ maintainer|trim }}
-{% endfor %}
+---
 
 <details><summary><h2>Contributing</h2></summary>
 
@@ -128,6 +124,12 @@ package above.
 
 ---
 {% endif %}
+
+## Maintainers
+
+{% for maintainer in cookiecutter.project_maintainers.split(";") %}
+- {{ maintainer|trim }}
+{% endfor %}
 
 ## Credit
 


### PR DESCRIPTION
# Changes

Hiding the details of the contribution and documentation sections of the README to make it less cluttered.

This suggestion came from @Simon-Coleman-TfN, who mentioned that some of the README's can have a very small description which is missed because there is lots of boiler plate stuff about documentation.

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases) - No
- [x] Has documentation (including user guide) been updated
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt`
- [ ] Code linting, tests and other workflows pass
