### PR TITLE
Lint: Add new linting rules for pandas and type annotations

### DIFF
--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -97,8 +97,6 @@ ignore = [
     "SIM108", # one line if else (flake8-bandit)
     "S311",   # random.random not allowed (flake8-bandit)
     "DOC502", # docstring-extraneous-exception (sometimes necessary)
-    "PD013",  # pandas.melt preferred over .stack
-    "PD010",  # pandas.pivot_table is preferred to .pivot or .unstack
     "ANN003", # type annotation for **kwargs
 ]
 unfixable = [

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -97,6 +97,9 @@ ignore = [
     "SIM108", # one line if else (flake8-bandit)
     "S311",   # random.random not allowed (flake8-bandit)
     "DOC502", # docstring-extraneous-exception (sometimes necessary)
+    "PD013",  # pandas.melt preferred over .stack
+    "PD010",  # pandas.pivot_table is preferred to .pivot or .unstack
+    "ANN003", # type annotation for **kwargs
 ]
 unfixable = [
     "T20",  # print-statements (flake8-print)

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -153,6 +153,8 @@ disable = [
     "use-dict-literal",
     "use-list-literal",
     "wrong-import-position", # Compatibility with ruff
+    "wrong-import-order",    # Handled by ruff
+    "ungrouped-imports",     # Handled by ruff
 ]
 
 [tool.pylint.basic]


### PR DESCRIPTION
# Changes

- Ignored ruff rules for pandas.stack / unstack, as I think we're happy to use them both
- Ignored type annotation rule for `**kwargs`, but **left the rule in for `*args`**

@BenTaylor-TfN, @isaac-tfn, @Kieran-Fishwick-TfN - any thoughts on these rules?

Closes #47

