### PR TITLE
Docs: updated README to new format

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,6 +11,8 @@
     "description": "Package description",
     "init_git": false,
     "push_repository": false,
+    "__docs_name": "{{ cookiecutter.project_slug.replace('.', '') }}",
+    "__readthedocs_url": "https://{{ cookiecutter.__docs_name }}.readthedocs.io/en",
     "_template_details": "filled by pre_prompt hook",
     "__pkg_folder": "{{ cookiecutter.package_name.replace('.', '/') }}",
     "_copy_without_render": [

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -1,4 +1,9 @@
-![Transport for the North Logo]({{ cookiecutter.github_url }}/blob/main/docs/TFN_Landscape_Colour_CMYK.png)
+<div align="center" style="background-color: white;">
+<a href="https://www.transportforthenorth.com/">
+<img src="https://www.transportforthenorth.com/wp-content/themes/tfn-theme/img/logo.svg"
+  alt="Transport for the North logo">
+</a>
+</div>
 
 <h1 align="center">{{ cookiecutter.__readable_name }}</h1>
 
@@ -6,6 +11,8 @@
 <a href="https://transport-for-the-north.github.io/CAF-Handbook/python_tools/framework.html">
   <img alt="CAF Status - Pre-Alpha" src="https://img.shields.io/badge/CAF%20Status-Pre--Alpha-orange">
 </a>
+</p>
+<p align="center">
 <a href="https://pypi.org/project/{{ cookiecutter.project_slug }}/">
   <img alt="Supported Python versions" src="https://img.shields.io/pypi/pyversions/{{ cookiecutter.project_slug }}.svg?style=flat-square">
 </a>
@@ -17,102 +24,169 @@
 </a>
 </p>
 <p align="center">
-<a href="https://app.codecov.io/gh/{{ cookiecutter.github_org }}/{{ cookiecutter.project_slug }}">
-  <img alt="Coverage" src="https://img.shields.io/codecov/c/github/{{ cookiecutter.github_org }}/{{ cookiecutter.project_slug }}.svg?branch=main&style=flat-square&logo=CodeCov">
-</a>
 <a href="{{ cookiecutter.github_url }}/actions?query=event%3Apush">
   <img alt="Testing Badge" src="https://img.shields.io/github/actions/workflow/status/{{ cookiecutter.github_org }}/{{ cookiecutter.project_slug }}/tests.yml?style=flat-square&logo=GitHub&label=Tests">
 </a>
-<a href='https://{{ cookiecutter.project_slug.replace(".", "") }}.readthedocs.io/en/stable/?badge=stable'>
-  <img alt='Documentation Status' src="https://img.shields.io/readthedocs/{{ cookiecutter.project_slug.replace('.', '') }}?style=flat-square&logo=readthedocs">
+<a href="https://app.codecov.io/gh/{{ cookiecutter.github_org }}/{{ cookiecutter.project_slug }}">
+  <img alt="Coverage" src="https://img.shields.io/codecov/c/github/{{ cookiecutter.github_org }}/{{ cookiecutter.project_slug }}.svg?branch=main&style=flat-square&logo=CodeCov">
 </a>
-<a href="https://github.com/psf/black">
-  <img alt="code style: black" src="https://img.shields.io/badge/code%20format-black-000000.svg">
+<a href='{{ cookiecutter.__readthedocs_url }}/stable/'>
+  <img alt='Documentation Status' src="https://img.shields.io/readthedocs/{{ cookiecutter.__docs_name }}?style=flat-square&logo=readthedocs">
 </a>
 </p>
 
 > [!WARNING]  
-> This package is in an early stage of development so features may change or be removed. 
-> If using this package it is recommended to set a specific version and check before 
+> This package is in an early stage of development so features may change or be removed.
+> If using this package it is recommended to set a specific version and check before
 > upgrading to a new version.
 
 {{ cookiecutter.description }}
 
+> [!TIP]
+> For more detailed information including a user guide, tutorials and API reference see the full
+> [{{ cookiecutter.project_slug }} documentation]({{ cookiecutter.__readthedocs_url }}/stable/)
+
 {% if cookiecutter.package_name == "package_name" %}
-Template usage and information is shown in [Template Usage](#template-usage) section below.
+> [!NOTE]
+> Template usage and information is shown in [Template Usage](#template-usage) section below.
 {% endif %}
+
+## Table of Contents
+
+- [Table of Contents](#table-of-contents)
+- [Overview](#overview)
+  - [What does it do?](#what-does-it-do)
+  - [Main Features](#main-features)
+    - [Work-in-Progress](#work-in-progress)
+  - [Who is it for?](#who-is-it-for)
+- [Where to get it](#where-to-get-it)
+  - [Installation from GitHub](#installation-from-github)
+- [Usage](#usage)
+  - [Command Line](#command-line)
+- [Documentation](#documentation)
+- [What is CAF?](#what-is-caf)
+- [Contribution](#contribution)
+- [Contact Us](#contact-us)
+- [Template Usage](#template-usage)
+
+## Overview
+
+### What does it do?
+
+> [!ATTENTION]
+> This section of the README hasn't been written yet, but it will contain a brief
+> description of what the tool is intended to do.
+
+### Main Features
+
+> [!ATTENTION]
+> This section of the README hasn't been written yet.
+
+- **Feature 1** - description
+
+#### Work-in-Progress
+
+- **Work in progress feature** - description of feature not yet release.
+
+> [!WARNING]
+> These features are work-in-progress and are not available in a released version of caf.space, to
+> access these features a specific branch of caf.space should be installed, see [Installation from GitHub](#installation-from-github).
+
+### Who is it for?
+
+- **Target audience:** *TODO*
+{% if cookiecutter.caf %}
+- **CAF Analytical Stage:** *TODO*
+
+![CAF Analytical Process Diagram](https://github.com/Transport-for-the-North/.github/blob/21a428e81880639839e221940881572cdee24d5a/profile/ProcessDiagram.png?raw=true)
+
+For more details on CAF Analytical Stages see the [description within TfN's GitHub homepage](https://github.com/Transport-for-the-North)
+{% endif %}
+
+## Where to get it
+
+> [!ATTENTION]
+> {{ cookiecutter.project_slug }} has not been published yet so cannot be installed from
+> conda-forge or PyPI, see [Installation from GitHub](#installation-from-github).
+
+The latest released version are available at the [Python
+Package Index (PyPI)](https://pypi.org/project/{{ cookiecutter.project_slug }}) and on [Conda](https://anaconda.org/conda-forge/{{ cookiecutter.project_slug }}).
+
+```sh
+conda install -c conda-forge {{ cookiecutter.project_slug }}
+```
+
+```sh
+pip install {{ cookiecutter.project_slug }}
+```
+
+> [!TIP]
+>
+> - See the [Quick Start Guide]({{ cookiecutter.__readthedocs_url }}/stable/start.html#quick-start) for more detailed instructions.
+> - See the [requirements.txt](requirements.txt) for the full list of package dependencies.
+
+### Installation from GitHub
+
+> [!WARNING]
+> Unreleased GitHub versions should **not** be considered stable.
+
+The latest, unreleased, version can be installed directly from GitHub using:
+
+```sh
+pip install "git+{{ cookiecutter.github_url }}"
+```
+
+> [!TIP]
+> `pip install` can install a specific tag, or branch, using `@{tag-name}`
+> after the git URL.
+
+## Usage
+
+CAF.space provides and Command-line (CLI) and graphical interface (GUI) to use many of it's
+features without the need to write any Python code, see the [Tool Usage section]({{ cookiecutter.__readthedocs_url }}/stable/usage/index.html)
+of the user guide for more details.
+
+### Command Line
+
+The tool can be run from command line, with the command:
+
+```sh
+{{ cookiecutter.project_slug }}
+```
+
+See [Command-Line Interface (User Guide)]({{ cookiecutter.__readthedocs_url }}/stable/usage/cli.html)
+for full explanations of the parameters.
+
+## Documentation
+
+The code documentation is hosted at <{{ cookiecutter.__readthedocs_url }}/stable/>.
 
 {% if cookiecutter.caf %}
 
-## Common Analytical Framework
+## What is CAF?
 
-This package is sits within the [Common Analytical Framework (CAF)](https://transport-for-the-north.github.io/caf_homepage/intro.html),
-which is a collaboration between transport bodies in the UK to develop and maintain commonly used
-transport analytics and appraisal tools.
+This tool is part of TfN's [Common Analytical Framework (CAF)](https://github.com/Transport-for-the-North).
+CAF is Transport for the North's structured suite of analytical tools designed to support transport
+modelling, appraisal, and strategic decision-making.
+
+More information on CAF and details on other CAF tools can be found on [TfN's GitHub Homepage](https://github.com/Transport-for-the-North).
 {% endif %}
 
+## Contribution
+
+We encourage use of, and contributions to, the repositories within this organisation, licenses are provided within
+the repositories and the [organisation contribution guide](https://github.com/Transport-for-the-North/.github/blob/main/CONTRIBUTING.rst)
+provides details for contributions.
+
 ---
 
-<details><summary><h2>Contributing</h2></summary>
+## Contact Us
 
-{{ cookiecutter.__readable_name }} happily accepts contributions.
+For further information about using this tool or CAF tools in your projects and work contact Transport for the North - <TfNOffer@transportforthenorth.com>
 
-The best way to contribute to this project is to go to the [issues tab]({{ cookiecutter.github_url}}/issues)
-and report bugs or submit a feature request. This helps {{ cookiecutter.__readable_name }} become more
-stable and full-featured. Please check the closed bugs before submitting a bug report to see if your
-question has already been answered.
-
-Please see our [contribution guidelines](https://github.com/Transport-for-the-North/.github/blob/main/CONTRIBUTING.rst)
-for details on contributing to the codebase or documentation.
-</details>
-
-<details><summary><h2>Documentation</h2></summary>
-
-Documentation is created using [Sphinx](https://www.sphinx-doc.org/en/master/index.html) and is hosted online at
-[{{ cookiecutter.project_slug.replace(".", "") }}.readthedocs](https://{{ cookiecutter.project_slug.replace(".", "") }}.readthedocs.io/en/stable/).
-
-The documentation can be built locally once all the docs requirements
-([`docs/requirements.txt`](docs/requirements.txt)) are installed into your Python environment.
-
-The provided make batch file, (inside the docs folder), allow for building the documentation in
-various target formats. The command for building the documentation is `make {target}`
-(called from within docs/), where `{target}` is the type of documentation format to build. A full
-list of all available target formats can be seen by running the `make` command without any
-arguments but the two most common are detailed below.
-
-### HTML
-
-The HTML documentation (seen on Read the Docs) can be built using the `make html` command, this
-will build the web-based documentation and provide an index.html file as the homepage,
-[`docs/build/html/index.html`](docs/build/html/index.html).
-
-### PDF
-
-The PDF documentation has some other requirements before it can be built as Sphinx will first
-build a [LaTeX](https://www.latex-project.org/) version of the documentation and then use an
-installed TeX distribution to build the PDF from those. If you already have a TeX distribution
-setup then you can build the PDF with `make latexpdf`, otherwise follow the instructions below.
-
-Installing LaTeX on Windows is best done using [MiKTeX](https://miktex.org/), as this provides a
-simple way of handling any additional TeX packages. Details of other operating systems and TeX
-distributions can be found on the [Getting LaTeX](https://www.latex-project.org/get/) page on
-LaTeX's website.
-
-MiKTeX provides an installer on its website [miktex.org/download](https://miktex.org/download),
-which will run through the process of getting it installed and setup. In addition to MiKTeX
-the specific process Sphinx uses for building PDFs is [Latexmk](https://mg.readthedocs.io/latexmk.html),
-which is a Perl script and so requires Perl to be installed on your machine, this can be done with an
-installer provided by [Strawberry Perl](https://strawberryperl.com/).
-
-Once MiKTex and Perl are installed you are able to build the PDF from the LaTeX files, Sphinx
-provides a target (latexpdf) which builds the LaTeX files then immediately builds the PDF. When
-running `make latexpdf` MiKTeX may ask for permission to installed some required TeX packages.
-Once the command has finished the PDF will be located at
-[`docs/build/latex/{{ cookiecutter.project_slug.replace(".", "") }}.pdf`](docs/build/latex/{{ cookiecutter.project_slug.replace(".", "") }}.pdf).
-</details>
+---
 
 {% if cookiecutter.package_name == "package_name" %}
----
 
 ## Template Usage
 
@@ -125,13 +199,4 @@ package above.
 ---
 {% endif %}
 
-## Maintainers
-
-{% for maintainer in cookiecutter.project_maintainers.split(";") %}
-- {{ maintainer|trim }}
-{% endfor %}
-
-## Credit
-
-This project was created using the Common Analytical Framework cookiecutter template found here:
-<https://github.com/Transport-for-the-North/cookiecutter-caf>
+[Go to Top](#table-of-contents)


### PR DESCRIPTION
# Changes

Updated README based on flatpack review, using caf.space as an example. Added readthedocs URL to cookiecutter variables as it's now used more often.

