### PR TITLE
Update workflows to include permissions where needed

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   generate:
     name: Generate Template & Test

--- a/{{ cookiecutter.project_slug }}/.github/workflows/linting.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/linting.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     timeout-minutes: 3

--- a/{{ cookiecutter.project_slug }}/.github/workflows/tests.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 3

--- a/{{ cookiecutter.project_slug }}/.github/workflows/typing.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/typing.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
 


### PR DESCRIPTION
Fix for issue discovered in security code scanning. See [https://github.com/Transport-for-the-North/caf.space/security/code-scanning/3](https://github.com/Transport-for-the-North/caf.space/security/code-scanning/3) for an example.

Explicitly fixes [https://github.com/Transport-for-the-North/cookiecutter-caf/security/code-scanning/1](https://github.com/Transport-for-the-North/cookiecutter-caf/security/code-scanning/1) too

Add an explicit permissions block so workflows do not inherit potentially broader defaults. This preserves existing functionality while preventing unintended write scopes if repo/org defaults change.
