### PR TITLE
Limit Dependabot PRs to security updates only

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/dependabot.yml
+++ b/{{ cookiecutter.project_slug }}/.github/dependabot.yml
@@ -9,4 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    # This will tell dependabot to only submit security update PRs
+    # If you want to bump minimum versions when available, increase this number. The default is 10.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
# Changes
Set open-pull-requests-limit to 0 for security updates only. I don't think it makes sense for us to be updating minimum versions of dependencies unless we need to for security reasons. This will keep our packages as accessible as normal.

This is documented [here](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-)

Depedabot's default open PR count is 10. Do we think we should be recommending a lower limit for private repos to protect our actions minutes? What would make sense? 3? 5?

# Tasks

- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Has documentation (including user guide) been updated
- [ ] Have new dependencies been added (or changed) in relevant `requirements.txt`
- [ ] Code linting, tests and other workflows pass
