### PR TITLE
Update Dependabot configuration for major updates only

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/dependabot.yml
+++ b/{{ cookiecutter.project_slug }}/.github/dependabot.yml
@@ -9,10 +9,17 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    # Only allow major version updates to reduce noise from minor/patch updates
+
     allow:
+      # Only allow major version updates to reduce noise from minor/patch updates
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+
+      # Allow minor versions for caf packages to ensure new versions are tested more often
+      - dependency-name: "caf.*"
+        update-types:
+          - "version-update:semver-minor"
+
     # If you only want security update PRs, set this to 0
     open-pull-requests-limit: 3

--- a/{{ cookiecutter.project_slug }}/.github/dependabot.yml
+++ b/{{ cookiecutter.project_slug }}/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    # This will tell dependabot to only submit security update PRs
-    # If you want to bump minimum versions when available, increase this number. We recommend a maximum value of 3.
-    open-pull-requests-limit: 0
+    # Only allow major version updates to reduce noise from minor/patch updates
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    # If you only want security update PRs, set this to 0
+    open-pull-requests-limit: 3


### PR DESCRIPTION
Configure Dependabot to allow only major version updates and set a limit on open pull requests.

# Tasks

- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Has documentation (including user guide) been updated
- [ ] Have new dependencies been added (or changed) in relevant `requirements.txt`
- [ ] Code linting, tests and other workflows pass
