### PR TITLE
Fix: exclude workflow files from gitignore

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       {% raw %}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/{{ cookiecutter.project_slug }}/.github/workflows/linting.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/linting.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/{{ cookiecutter.project_slug }}/.github/workflows/linting.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/linting.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             requirements.txt
             requirements_dev.txt

--- a/{{ cookiecutter.project_slug }}/.github/workflows/tests.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
+        cache: "pip"
         cache-dependency-path: |
           requirements.txt
           requirements_dev.txt
@@ -36,8 +36,7 @@ jobs:
         pip install -r requirements_dev.txt
 
     - name: Test with PyTest
-      run:
-        pytest
+      run: pytest
 
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v4

--- a/{{ cookiecutter.project_slug }}/.github/workflows/typing.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/typing.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/{{ cookiecutter.project_slug }}/.github/workflows/typing.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/typing.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             requirements.txt
             requirements_dev.txt

--- a/{{ cookiecutter.project_slug }}/.gitignore
+++ b/{{ cookiecutter.project_slug }}/.gitignore
@@ -160,3 +160,6 @@ dmypy.json
 # Specific configs can be included using '!' https://git-scm.com/docs/gitignore#_pattern_format
 # All configs in the examples folder are included
 !examples/*.yml
+!.github/**/*.yml
+!.readthedocs.yaml
+!.codecov.yml

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.urls]


### PR DESCRIPTION
# Changes

- Make sure workflow and CI tool config YAMLs are included in the repo.
- Added Python v3.14 to workflows
- Minor workflow maintenance updates (e.g., actions/checkout@v4, YAML formatting tweaks)