### PR TITLE
CI: dependabot config for major versions & minor caf

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/dependabot.yml
+++ b/{{ cookiecutter.project_slug }}/.github/dependabot.yml
@@ -1,25 +1,25 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
-
+      interval: "cron"
+      cronjob: "0 0 28 * *"
     allow:
       # Only allow major version updates to reduce noise from minor/patch updates
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-
       # Allow minor versions for caf packages to ensure new versions are tested more often
       - dependency-name: "caf.*"
         update-types:
           - "version-update:semver-minor"
-
     # If you only want security update PRs, set this to 0
     open-pull-requests-limit: 3
+
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 28 * *"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
# Changes

Updated dependabot config to run at the end of the month (28th) and to check GitHub actions versions. Also, switched to only work for major package versions and minors for caf packages.

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases) - NA
- [x] Has documentation (including user guide) been updated - NA
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - NA
- [ ] Code linting, tests and other workflows pass
